### PR TITLE
Update Tizen code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ build.gradle:
 
 ### Tizen
 
-This plugin requires Tizen 5.5+.
+This plugin requires Tizen 4.0+.
 
 Make the following changes to `tizen/tizen-manifest.xml`:
 ```
-<manifest api-version="5.5" ...>
+<manifest api-version="4.0" ...>
     <privileges>
         <privilege>http://tizen.org/privilege/healthinfo</privilege>
     </privileges>

--- a/example/tizen/NuGet.Config
+++ b/example/tizen/NuGet.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-    <add key="tizen.myget.org" value="https://tizen.myget.org/F/dotnet/api/v3/index.json" protocolVersion="3" />
-  </packageSources>
-</configuration>

--- a/example/tizen/Runner.csproj
+++ b/example/tizen/Runner.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Tizen.Flutter.Embedding" Version="$(FlutterEmbeddingVersion)*" />
+    <ProjectReference Include="$(FlutterEmbeddingPath)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/tizen/tizen-manifest.xml
+++ b/example/tizen/tizen-manifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest api-version="5.5" package="dev.rexios.workout_example" version="1.0.0"
+<manifest api-version="4.0" package="dev.rexios.workout_example" version="1.0.0"
     xmlns="http://tizen.org/ns/packages">
     <profile name="common" />
     <ui-application api-version="4" appid="dev.rexios.workout_example" exec="Runner.dll"

--- a/tizen/project_def.prop
+++ b/tizen/project_def.prop
@@ -2,7 +2,7 @@
 # for details.
 
 APPNAME = health_tizen_plugin
-type = sharedLib
+type = staticLib
 profile = common-4.0
 
 # Source files
@@ -11,22 +11,12 @@ USER_SRCS += src/health_tizen_plugin.cc
 # User defines
 USER_DEFS =
 USER_UNDEFS =
-USER_CPP_DEFS = TIZEN_DEPRECATION DEPRECATION_WARNING FLUTTER_PLUGIN_IMPL
+USER_CPP_DEFS = FLUTTER_PLUGIN_IMPL
 USER_CPP_UNDEFS =
 
-# Compiler/linker flags
+# Compiler flags
 USER_CFLAGS_MISC =
-USER_CPPFLAGS_MISC = -c -fmessage-length=0
-USER_LFLAGS =
-
-# Libraries and objects
-# To provide libraries for your plugin, you must put them in specific
-# directories that match their supporting cpu architecture type.
-# Due to compatibility issue with Tizen CLI, directory names must be armel for arm 
-# and i586 for x86.
-USER_LIB_DIRS = lib/${BUILD_ARCH}
-USER_LIBS =
-USER_OBJS =
+USER_CPPFLAGS_MISC =
 
 # User includes
 USER_INC_DIRS = inc src

--- a/tizen/src/health_tizen_plugin.cc
+++ b/tizen/src/health_tizen_plugin.cc
@@ -69,7 +69,7 @@ private:
             const EncodableList argumentList = get<EncodableList>(arguments);
             for (int i = 0; i < argumentList.size(); i++) {
                 string stringArgument = get<string>(argumentList[i]);
-                sensor_listener_h listener;
+                sensor_listener_h listener = nullptr;
                 sensorListeners.push_front(listener);
                 if (stringArgument == "heartRate") {
                     error += "" + startSensor(SENSOR_HRM, listener);


### PR DESCRIPTION
- [README.md/tizen-manifest.xml] Change Tizen API version to 4.0 to avoid deprecation warnings.
- [Runner.csproj] Migrate `PackageReference` to `ProjectReference`.
  - `PackageReference` is deprecated since https://github.com/flutter-tizen/flutter-tizen/pull/103
- [project_def.prop] Migrate `sharedLib` to `staticLib` and clean up.
  - `sharedLib` is deprecated since https://github.com/flutter-tizen/flutter-tizen/pull/195.
- Fix build error regarding `-Wuninitialized`.