### PR TITLE
Changed Speed Units From km/h To m/s

### DIFF
--- a/lib/src/model/workout_feature.dart
+++ b/lib/src/model/workout_feature.dart
@@ -15,6 +15,6 @@ enum WorkoutFeature {
   /// Distance traveled in meters
   distance,
 
-  /// Speed in km/h
+  /// Speed in m/s
   speed,
 }


### PR DESCRIPTION
Changed According to the Android [documentation](https://developer.android.com/reference/kotlin/androidx/health/services/client/data/DataType#SPEED():~:text=current%20active%20exercise.-,SPEED,Speed%20at%20a%20specific%20point%20in%20time%2C%20expressed%20as%20meters/second.,-SPEED_STATS) for the `androix.health.services.client.data.DataType` class.