### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.11
+
+- Updates minimum supported SDK version to Flutter 3.44/Dart 3.12.
+- Migrates to built-in Kotlin
+
 ## 0.6.10
 
 - Supports SwiftPM

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'dev.rexios.workout'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.0.21'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdk 34
@@ -40,16 +37,16 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = '11'
-    }
-
     namespace "dev.rexios.workout"
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+    }
+}
 
+dependencies {
     api 'androidx.health:health-services-client:1.1.0-alpha05'
     implementation 'com.google.guava:guava:32.0.1-android'
     implementation 'androidx.concurrent:concurrent-futures-ktx:1.2.0'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,14 +1,14 @@
+plugins {
+    id "com.android.application"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
     localPropertiesFile.withReader('UTF-8') { reader ->
         localProperties.load(reader)
     }
-}
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
@@ -20,9 +20,6 @@ def flutterVersionName = localProperties.getProperty('flutter.versionName')
 if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
-
-apply plugin: 'com.android.application'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdk 34

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -22,7 +22,6 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
@@ -31,10 +30,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -60,10 +55,12 @@ android {
     namespace 'dev.rexios.workout_example'
 }
 
-flutter {
-    source '../..'
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+flutter {
+    source '../..'
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '2.0.21'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,5 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.newDsl=false
+android.builtInKotlin=false

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,25 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version '8.8.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.0.21" apply false
+}
+
+include ":app"

--- a/lib/src/model/exercise_type.dart
+++ b/lib/src/model/exercise_type.dart
@@ -860,8 +860,8 @@ enum ExerciseType {
 
   /// Constructor
   const ExerciseType({required int androidId, required int iosId})
-      : _iosId = iosId,
-        _androidId = androidId;
+    : _iosId = iosId,
+      _androidId = androidId;
 
   /// Returns the [ExerciseType] for the given [id]
   static ExerciseType? fromId(int id) {

--- a/lib/src/model/workout_reading.dart
+++ b/lib/src/model/workout_reading.dart
@@ -15,7 +15,7 @@ class WorkoutReading {
 
   /// Constructor
   WorkoutReading(this.feature, this.value, int? timestamp)
-      : timestamp = timestamp != null
-            ? DateTime.fromMillisecondsSinceEpoch(timestamp)
-            : DateTime.timestamp();
+    : timestamp = timestamp != null
+          ? DateTime.fromMillisecondsSinceEpoch(timestamp)
+          : DateTime.timestamp();
 }

--- a/lib/src/workout_base.dart
+++ b/lib/src/workout_base.dart
@@ -30,8 +30,9 @@ class Workout {
   Future<List<ExerciseType>> getSupportedExerciseTypes() async {
     if (!Platform.isAndroid) return [];
 
-    final result =
-        await _channel.invokeListMethod<int>('getSupportedExerciseTypes');
+    final result = await _channel.invokeListMethod<int>(
+      'getSupportedExerciseTypes',
+    );
 
     final types = <ExerciseType>[];
     for (final id in result!) {
@@ -109,8 +110,9 @@ class Workout {
       WorkoutFeature.distance,
       WorkoutFeature.speed,
     };
-    final requestedActivityRecognitionFeatures =
-        _currentFeatures.toSet().intersection(activityRecognitionFeatures);
+    final requestedActivityRecognitionFeatures = _currentFeatures
+        .toSet()
+        .intersection(activityRecognitionFeatures);
 
     if (requestedActivityRecognitionFeatures.isNotEmpty) {
       final status = await Permission.activityRecognition.request();
@@ -172,17 +174,14 @@ class Workout {
     WorkoutSwimmingLocationType? swimmingLocationType,
     double? lapLength,
   }) async {
-    final result = await _channel.invokeMapMethod<String, dynamic>(
-      'start',
-      {
-        'exerciseType': exerciseType?.id,
-        'sensors': sensors,
-        'enableGps': enableGps,
-        'locationType': locationType?.id,
-        'swimmingLocationType': swimmingLocationType?.id,
-        'lapLength': lapLength,
-      },
-    );
+    final result = await _channel.invokeMapMethod<String, dynamic>('start', {
+      'exerciseType': exerciseType?.id,
+      'sensors': sensors,
+      'enableGps': enableGps,
+      'locationType': locationType?.id,
+      'swimmingLocationType': swimmingLocationType?.id,
+      'lapLength': lapLength,
+    });
     return WorkoutStartResult.fromResult(result);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: workout
 description: Run a workout session on Wear OS and Tizen. Get data such as heart rate in real time.
-version: 0.6.10
+version: 0.6.11
 homepage: https://github.com/Rexios80/flutter_workout
 
 environment:
-  sdk: ^3.0.0
-  flutter: ">=1.20.0"
+  sdk: ^3.12.0
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- Migrates the plugin to built-in Kotlin: removes the explicit Kotlin Gradle Plugin usage (`apply plugin: 'kotlin-android'`, the `kotlin-gradle-plugin` buildscript classpath, `ext.kotlin_version`, and the explicit `kotlin-stdlib` dependency) and adds a `kotlin { compilerOptions { jvmTarget = ... } }` block.
- Raises minimum SDK to Flutter 3.44 / Dart 3.12, patch-bumps the version, and adds a CHANGELOG entry.
- Migrates the example app per the [app-developer guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers) (adds `android.builtInKotlin=false` / `android.newDsl=false`, removes the `kotlin-android` plugin and `kotlinOptions` where present). No AGP upgrade.

See the [plugin-author migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

## Test plan
- [ ] CI passes
- [ ] Example builds after the separate AGP 9 upgrade

Made with [Cursor](https://cursor.com)